### PR TITLE
Regression: stdout listener was not removed

### DIFF
--- a/src/debug/debug.ts
+++ b/src/debug/debug.ts
@@ -105,7 +105,7 @@ class OCamlDebugSession extends DebugSession {
                     output = output.replace(/\n$/, '');
                     this.log(`ocd: ${JSON.stringify(output)}`);
                     resolve(output);
-                    this._debuggerProc.stdout.removeListener('data', onData);
+                    this._debuggerProc[DECODED_STDOUT].removeListener('data', onData);
                 }
             };
             this._debuggerProc[DECODED_STDOUT].on('data', onData);


### PR DESCRIPTION
Looks like you broke that in 6ead1171bf6746cae72964771a4fca4cbb352e04
