### PR TITLE
Readme: use js instead of json highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ clean:
 .PHONY: build clean
 ```
 
-```json
+```js
 // .vscode/tasks.json
 {
     "version": "0.1.0",
@@ -88,7 +88,7 @@ clean:
 }
 ```
 
-```json
+```js
 // .vscode/launch.json
 {
     "version": "0.2.0",


### PR DESCRIPTION
This way comments are rendered properly on GitHub.

Now:
![](http://i.imgur.com/j1SzsE2.png)

Before:
![](http://i.imgur.com/ZNhh1eu.png)
