### PR TITLE
Don't use UTF8 for merlin communication

### DIFF
--- a/src/merlin.ts
+++ b/src/merlin.ts
@@ -18,6 +18,8 @@ export class OCamlMerlinSession {
         this._cp.on('exit', (code, signal) => {
             log(`OCamlmerlin exited with code ${code}, signal ${signal}`);
         });
+        this._cp.stdout.setEncoding("ascii");
+        this._cp.stdin.setDefaultEncoding("ascii");
 
         this._rl = readline.createInterface({
             input: this._cp.stdout,


### PR DESCRIPTION
I've had a problem where Merlin absolutely wouldn't find local modules and always reported an "unbound module".
After some tedious debugging using the `MERLIN_LOG` environment variable I found out it didn't find my `.merlin` files (`"dot_merlin - update filenames"` with my path was followed by an empty `"dot_merlin - update files"` message, and when testing the [relevant pieces](https://github.com/the-lambda-church/merlin/blob/7efcb2265ed6525bf330666713f70cc83b32ce66/src/kernel/dot_merlin.ml#L108-L136) from the merlin source on my console I found out I had to enter `\228` instead of `ä` as part of my path to get `Sys.file_exists` to work). Oh my, a dreaded encoding incompatibility.
Indeed this must have been the problem, since when I moved my repository to a path not containing any umlauts the whole thing started working.

I have no idea where the real bug lies (Ocaml for Windows? Merlin? Vscode-ocaml?) but I'd guess it's the boundary between this extension and merlin, and fixing the extension was the easiest for me. Apparently it uses UTF8 by default, which merlin doesn't understand (at least for filenames?). I don't know which encoding it actually uses, I suspect Latin-1 but am not sure.
Instead of using [iconv](https://www.npmjs.com/package/iconv) or [iconv-lite](https://www.npmjs.com/package/iconv-lite) in the exact right places, maybe even a transform stream (?), I went the easy way and called [`setDefaultEncoding`](https://nodejs.org/api/stream.html#stream_writable_setdefaultencoding_encoding) and [`setEncoding`](https://nodejs.org/api/stream.html#stream_readable_setencoding_encoding) on the child process' io streams directly, using `"ascii"` as the encoding though I've got no idea how exactly it treats umlauts. It seemed to be working and I'm fine…
No idea if this is a proper fix, but consider the pull request as a bug report at least.