### PR TITLE
Fix 'as' coloration if type constraint contains 'as'

### DIFF
--- a/syntaxes/OCaml.YAML-tmLanguage
+++ b/syntaxes/OCaml.YAML-tmLanguage
@@ -694,8 +694,6 @@ repository:
         patterns:
         - include: '#matchpatterns'
     - include: '#storagetypes'
-    - name: keyword.other.ocaml
-      match: 'as'
     - name: variable.parameter.ocaml
       match: \b[a-z_][a-zA-Z0-9'_]*
 foldingStartMarker: (\b(module|class|)\s.*?=\s*$|\bbegin|sig|struct|(object(\s*\(_?[a-z]+\))?)\s*$|\bwhile\s.*?\bdo\s*$|^let(?:\s+rec)?\s+[a-z_][a-zA-Z0-9_]*\s+(?!=)\S)


### PR DESCRIPTION
Example:

    let foo (astast:ast) = ()

then both occurences of 'as' in 'astast' are picked as keywords.

I saw that the pattern on `as` had been duplicated as part of the issue "better syntax highlighting with dracula theme" in #49. That said, I don't really grasp the necessity for this duplicate pattern ('as' is already defined L378). I am sure that you had an excellent reason for adding this pattern! 😁

![capture d ecran 2017-05-17 a 09 45 35](https://cloud.githubusercontent.com/assets/2195781/26143522/a037642e-3ae5-11e7-9cae-b1859fcbab3e.png)
